### PR TITLE
[server] add environment variable `RM2FB_DISABLE` for disabling rm2fb client

### DIFF
--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -57,16 +57,16 @@ static void _libhook_init() {
     setenv("RM2FB_ACTIVE", "1", true);
   }
 
-  if (getenv("RM2FB_DISABLE") != "") {
-    DISABLED = true;
-    return;
-  }
-
   qImageCtor = (void (*)(void *, int, int, int))dlsym(
       RTLD_NEXT, "_ZN6QImageC1EiiNS_6FormatE");
   qImageCtorWithBuffer = (void (*)(
       void *, uint8_t *, int32_t, int32_t, int32_t, int, void (*)(void *),
       void *))dlsym(RTLD_NEXT, "_ZN6QImageC1EPhiiiNS_6FormatEPFvPvES2_");
+
+  if (getenv("RM2FB_DISABLE") != "") {
+    DISABLED = true;
+    return;
+  }
 
   SHARED_BUF = swtfb::ipc::get_shared_buffer();
 }


### PR DESCRIPTION
the plan is to enable rm2fb for all systemd units, but disable it for
the rm2fb server unit with this environment variable