### PR TITLE
[ioctl] add implementation of wait ioctl using semaphores

### DIFF
--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -16,6 +16,7 @@
 #include <dlfcn.h>
 #include <mutex>
 #include <stdint.h>
+#include <semaphore.h>
 #include <thread>
 
 #include <QCoreApplication>
@@ -144,6 +145,15 @@ int server_main(int, char **argv, char **) {
       fb.SendUpdate(rect, buf.xochitl_update.waveform,
                     buf.xochitl_update.flags);
     } break;
+    case ipc::WAIT_t: {
+      fb.WaitForLastUpdate();
+      sem_t* sem = sem_open(buf.wait_update.sem_name, O_CREAT, 0644, 0);
+      if (sem != NULL) {
+        sem_post(sem);
+        sem_close(sem);
+      }
+    } break;
+
     default:
       std::cerr << "Error, unknown message type" << std::endl;
     }


### PR DESCRIPTION
Squashed merge to clean up conflicts in PR #45's multi-fork history
Full commit history:

    commit 7ab9f34763df62b80562b86cc57ce193ab25cee3
    Author: Mattéo Delabre <1370040+matteodelabre@users.noreply.github.com>
    Date:   Thu Feb 18 03:33:52 2021 +0100

        Make the client shim a no-op on reMarkable 1 (#47)

        * Make the client shim a no-op on reMarkable 1

        This PR is intended to make it safe to load the `librm2fb_client`
        library even when running on reMarkable 1. This is so that Toltec can
        ship all the binaries that need to access the framebuffer with a dynamic
        dependency on librm2fb_client, and eliminate the need to set the
        LD_PRELOAD environment variable when starting those binaries.

        In the library constructor, the `/sys/devices/soc0/machine` file is read
        to determine whether we’re running on rM1 or rM2, and set the ON_RM2
        flag accordingly. When this flag is off, the wrapped system calls
        directly forward their arguments to the standard library.

        I also cleaned up some parts of the existing code, in particular:

        - Removed repeated function pointer types, when possible.
        - Moved most file globals to block-level static variables.
        - Removed the main function definition that looked redundant.

        Test plan:

        - Built `librm2fb_client.so.1.0.0` and checked that the exported symbols
          did not change compared to the last version (using
          `arm-oe-linux-gnueabi-objdump -T librm2fb_client.so.1.0.0 | grep "DF .text"`),
          except for the removed `main` symbol:
          * `_ZN6QImageC1EiiNS_6FormatE`
          * `_Z7qputenvPKcRK10QByteArray`
          * `ioctl`
          * `open64`
          * `open`
          * `close`
          * `__libc_start_main`
        - **On rM1,** ran `LD_PRELOAD=./librm2fb_client.so.1.0.0 xochitl`,
          checked that no preloading errors occurred and that no messages from the
          shim appeared. Checked that the display worked correctly and that the
          touchscreen was not inverted.
        - **On rM1,** ran `LD_PRELOAD=./librm2fb_client.so.1.0.0 calculator` and
          performed the same checks as in the previous item.
        - **On rM2,** ran `LD_PRELOAD=./librm2fb_client.so.1.0.0 xochitl` and
          checked that no preloading errors occurred, and that the following
          messages from the shim appeared:

        ```
        OPENED SHARED MEM: /dev/shm/swtfb.01 at 72c2e000, errno: 0
        Update fn address: 0x2c050c
        Create th address: 0x2c2798
        Wait for th address: 0x2c1fd4
        shutdown address: 0x2c273c
        REPLACING THE IMAGE with shared memory
        create threads called
        wait clear func called
        ```

          Also checked that the display worked correctly and that the
          touchscreen was not inverted.
        - **On rM2,** ran `LD_PRELOAD=./librm2fb_client.so.1.0.0 calculator` and
          checked that no preloading errors occurred, that the display worked
          correctly, and that the touchscreen was not inverted.

        * Only set RM2FB_* env vars on rM2

commit 495c051adf622afba726a1176470a9a7f6821d11
Author: Glen Sawyer <github@snelg.com>
Date:   Tue Feb 9 20:28:45 2021 -0700

    sem_timedwait is based on absolute time, not relative (#46)

    * sem_timedwait is based on absolute time, not relative
    * Fix tv_nsec wraparound
    * Simpler representation of 1,000,000,000

commit 3594d5aeeb758e9524902a9884ee6a536100ab79
Author: okay <okay@chalk>
Date:   Mon Feb 8 08:09:49 2021 -0800

    [wait] update comments

commit e91fc5abcab082e0c4d0e3c4c4244bbae8558313
Author: okay <okay@chalk>
Date:   Sun Feb 7 21:55:24 2021 -0800

    [ioctl] use sem_timedwait as outlined in task

commit 8725b8e8136e36e96371c02525a4e15ceffb352b
Author: okay <okay@chalk>
Date:   Sun Feb 7 21:47:39 2021 -0800

    [ioctl] add implementation of wait ioctl using semaphores