### PR TITLE
Disable link to Qt GUI and unset rpath in client

### DIFF
--- a/src/client/client.pro
+++ b/src/client/client.pro
@@ -21,4 +21,6 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # Input
 SOURCES += main.cpp
 CONFIG += hide_symbols
+QT -= gui
+QMAKE_LFLAGS_RPATH=
 LIBS += -lrt -ldl frida/libfrida-gum.a -Wl,--exclude-libs,ALL


### PR DESCRIPTION
Fixes #52.

Depending on the toolchain configuration, the client shim (librm2fb_client.so) might get linked to libQt5Gui.so and get its rpath
set to a fixed value. In particular, the setting of rpath implies that any binary which preloads the shim will ignore LD_LIBRARY_PATH, causing issue #52. This PR adds the necessary configuration to `client.pro` to make sure that this does not happen.

Test plan:

* Build librm2fb_client.so and check the dynamic section of the resulting library with objdump. Notice that RPATH is not set and that libQt5Gui.so is not in the list of NEEDED libs.
* Preload the built library into KOReader and make sure it does not crash on start, even if the `/opt/koreader/cache/fontinfo.dat` file is missing.