### PR TITLE
client: Add flag to disable Xochitl intercept

### DIFF
--- a/src/client/client.pro
+++ b/src/client/client.pro
@@ -23,4 +23,8 @@ SOURCES += main.cpp
 CONFIG += hide_symbols
 QT -= gui
 QMAKE_LFLAGS_RPATH=
-LIBS += -lrt -ldl frida/libfrida-gum.a -Wl,--exclude-libs,ALL
+LIBS += -lrt -ldl -Wl,--exclude-libs,ALL
+
+!contains(DEFINES, NO_XOCHITL) {
+    LIBS += frida/libfrida-gum.a
+}

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -19,7 +19,9 @@
 #include "../shared/ipc.cpp"
 #include "../shared/signature.cpp"
 
+#ifndef NO_XOCHITL
 #include "frida/frida-gum.h"
+#endif
 
 #define SEM_WAIT_TIMEOUT 200000000 /* 200 * 1000 * 1000, e.g. 200ms */
 
@@ -291,6 +293,8 @@ std::string readlink_string(const char* link_path) {
   return buffer;
 }
 
+#ifndef NO_XOCHITL
+
 struct Signature {
   const char* bytes;
   int N;
@@ -380,4 +384,7 @@ int __libc_start_main(int (*_main)(int, char **, char **), int argc,
 
   return func_main(_main, argc, argv, init, fini, rtld_fini, stack_end);
 }
-};
+
+#endif // NO_XOCHITL
+
+} // extern "C"


### PR DESCRIPTION
Running `qmake client.pro DEFINES+=NO_XOCHITL` will generate librm2fb_client.so without the Xochitl interception logic (and will not link to frida-gum).

Rationale:

* Libs and binaries on the reMarkable system are compiled using the hardfloat (hf) ABI, libs and binaries from Entware are compiled using the softfloat (sf) ABI. The two ABIs are incompatible with each other (a hf binary cannot be linked to a sf library, and vice versa).
* To make Toltec independent from reMarkable system updates, I plan on adding Qt libraries in /opt and to make apps only load libraries from that folder. This will require recompiling all Toltec apps and libraries to use the sf ABI (since Entware libs also live in /opt and those use the sf ABI).
* rm2fb will therefore need to be compiled for the two ABIs, the sf version being used for Toltec apps, and the hf version being used for Xochitl.
* This new NO_XOCHITL flag will be useful for the sf version which doesn’t need the Xochitl interception logic. In fact, without this flag, we would need to recompile all of frida-gum for the sf ABI, since the Frida project only provides hf releases.