### PR TITLE
Implement indirect signatures and use them for locating update_fn

### DIFF
--- a/src/shared/signature.cpp
+++ b/src/shared/signature.cpp
@@ -1,58 +1,83 @@
 // ./a.out < xochitl
 // ./a.out < remarkable-shutdown
 
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <errno.h>
+#include <string>
+#include <fstream>
+#include <sstream>
+
 
 namespace swtfb {
-// from https://stackoverflow.com/a/14002993/442652
-char *read_file(const char *filename, int *out_size) {
-  FILE *f = fopen(filename, "rb");
-  if (f == NULL) {
-    fprintf(stderr, "Unable to open %s: %s\n", filename, strerror(errno));
-    exit(-1);
-  }
-  fseek(f, 0, SEEK_END);
-  long fsize = ftell(f);
-  fseek(f, 0, SEEK_SET); /* same as rewind(f); */
+struct Signature {
+  bool indirect;
+  std::string bytes;
+  int offset;
+};
 
-  char *string = (char *)malloc(fsize + 1);
-  fread(string, 1, fsize, f);
-  fclose(f);
-
-  string[fsize] = 0;
-  *out_size = fsize;
-
-  return string;
+std::string read_file(const std::string& path) {
+  std::ostringstream output;
+  std::ifstream input_file{path, std::ifstream::binary};
+  output << input_file.rdbuf();
+  return std::string(output.str());
 }
 
-char *locate_signature(const char *path, const char *find, int N) {
-  int size;
-  char *data = read_file(path, &size);
+std::int32_t decode_jump_offset(std::string instruction) {
+  // Assuming A1 or A2 (4 bytes) instruction encoding
+  // See section A8.8.25 of the ARMv7 Architecture Reference Manual
+  char byte_0 = instruction[0];
+  char byte_1 = instruction[1];
+  char byte_2 = instruction[2];
+  char byte_3 = instruction[3];
 
-  int offset = 0x10000;
-  char *ret = NULL;
+  if (((byte_3 >> 1) & 0b111) != 0b101) {
+    // Not a jump instruction
+    return 0;
+  }
 
-  bool found;
-  for (int i = 0; i < size - N; i++) {
-    found = true;
-    for (int j = 0; j < N; j++) {
-      if (find[j] != data[i + j]) {
-        found = false;
-        break;
-      }
+  std::int32_t res = (
+    (byte_2 << 16)
+    | (byte_1 << 8)
+    | byte_0
+  );
+
+  bool is_negative = byte_2 >> 7;
+
+  if (is_negative) {
+    res |= (0xff << 24);
+  }
+
+  return (res << 2) + 8;
+}
+
+void *locate_signature(const std::string& data, const Signature& signature) {
+  const size_t base_offset = 0x10000;
+  const size_t position = data.find(signature.bytes);
+
+  if (position == std::string::npos) {
+    return nullptr;
+  }
+
+  if (!signature.indirect) {
+    return (char *) position + base_offset - 4 + signature.offset;
+  } else {
+    auto jump_offset = decode_jump_offset(data.substr(position + signature.offset, 4));
+
+    if (jump_offset == 0) {
+      return nullptr;
     }
 
-    if (found) {
-      ret = (char *)i + offset - 4;
-      break;
+    return (char*) position + signature.offset + base_offset + jump_offset;
+  }
+}
+
+void *locate_signature(const std::string& data, const std::vector<Signature>& signatures) {
+  for (const Signature& signature : signatures) {
+    void *result = locate_signature(data, signature);
+
+    if (result != nullptr) {
+      return result;
     }
   }
 
-  free(data);
-  return ret;
+  return nullptr;
 }
 } // namespace swtfb

--- a/src/shared/swtfb.cpp
+++ b/src/shared/swtfb.cpp
@@ -30,8 +30,12 @@ public:
   }
 
   void setFunc() {
-    int *addr =
-        (int *)locate_signature(SDK_BIN.c_str(), "|@\x9f\xe5|P\x9f\xe5", 8);
+    auto data = swtfb::read_file(SDK_BIN);
+    void *addr = locate_signature(data, {
+      /* indirect = */ false,
+      /* bytes = */ {"|@\x9f\xe5|P\x9f\xe5", 8},
+      /* offset = */ 0,
+    });
     if (addr != 0) {
       f_getInstance = (uint32_t * (*)(void)) addr;
       fprintf(stderr, "ADDR: %x\n", addr);


### PR DESCRIPTION
This PR contains an implementation for what I call “indirect signatures”, i.e., instead of searching for a byte sequence located a fixed distance away from the start of the function of interest, we search for a byte sequence next to a jump instruction that points to the function of interest. We can take advantage of this technique to find a signature for `update_fn` that is stable across multiple versions (I checked in 2.3, 2.5, 2.6, and 2.8).

This patch will need to be tested on multiple Xochitl versions (for each one, the thing to be tested is that Xochitl correctly displays its interface when launched with `LD_PRELOAD=path/to/librm2fb_client.so.1.0.1`). Currently, I only tested it on 2.8.0, and I will take care of testing more versions tomorrow.