### PR TITLE
Update timespec overflow implementation

### DIFF
--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -172,10 +172,9 @@ int ioctl(int fd, unsigned long request, char *ptr) {
       }
 
       timeout.tv_nsec += SEM_WAIT_TIMEOUT;
-      if (timeout.tv_nsec >= 1e9) {
-        timeout.tv_nsec -= 1e9;
-        timeout.tv_sec++;
-      }
+      // Move overflow ns to secs (1000000000 = 1e9 = 1s in ns)
+      timeout.tv_sec += timeout.tv_nsec / 1000000000;
+      timeout.tv_nsec %= 1000000000;
 
       sem_timedwait(sem, &timeout);
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -172,9 +172,9 @@ int ioctl(int fd, unsigned long request, char *ptr) {
       }
 
       timeout.tv_nsec += SEM_WAIT_TIMEOUT;
-      // Move overflow ns to secs (1000000000 = 1e9 = 1s in ns)
-      timeout.tv_sec += timeout.tv_nsec / 1000000000;
-      timeout.tv_nsec %= 1000000000;
+      // Move overflow ns to secs
+      timeout.tv_sec += timeout.tv_nsec / (uint64_t) 1e9;
+      timeout.tv_nsec %= (uint64_t) 1e9;
 
       sem_timedwait(sem, &timeout);
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -173,8 +173,8 @@ int ioctl(int fd, unsigned long request, char *ptr) {
 
       timeout.tv_nsec += SEM_WAIT_TIMEOUT;
       // Move overflow ns to secs
-      timeout.tv_sec += timeout.tv_nsec / (uint64_t) 1e9;
-      timeout.tv_nsec %= (uint64_t) 1e9;
+      timeout.tv_sec += timeout.tv_nsec / (long) 1e9;
+      timeout.tv_nsec %= (long) 1e9;
 
       sem_timedwait(sem, &timeout);
 


### PR DESCRIPTION
This was raised by @fenollp when reviewing the rust-impl of this client.

https://github.com/canselcik/libremarkable/pull/78#discussion_r748864139

The code wouldn't work properly if SEM_WAIT_TIMEOUT would be greater
than one second, since only one overflow is accounted for with an "if".

Using modulo here instead of while so no branching is needed and it
would scale linearly not not require one loop per overflown second.

(I didn't use 1e9 since it's a double and I'm not sure if it would be perfectly accurate in C++, feel free to change if you don't mind.)