### PR TITLE
Add Beta 2.11.0.433 support

### DIFF
--- a/src/shared/config.cpp
+++ b/src/shared/config.cpp
@@ -145,6 +145,15 @@ create addr 0x39aee0
 shutdown addr 0x39ae84
 wait addr 0x39a404
 getInstance addr 0x38f3b4
+
+!20211202111519
+version str 2.11.0.433
+update addr 0x3a9ccc
+updateType str QRect
+create addr 0x3ac124
+shutdown addr 0x3ac0c8
+wait addr 0x3ab604
+getInstance addr 0x3a041c
 )CONF";
 
 void read_config_file(


### PR DESCRIPTION
Custom launchers such as Oxide or Remux don't seem to work however:

    Dec 04 17:13:51 reMarkable systemd[1]: Started reMarkable 2 Framebuffer Server.
    Dec 04 17:13:51 reMarkable xochitl[194]: STARTING RM2FB
    Dec 04 17:13:51 reMarkable xochitl[194]: getInstance() at address: 0x3a9f80
    Dec 04 17:13:51 reMarkable xochitl[194]: REPLACING THE IMAGE with shared memory
    Dec 04 17:13:55 reMarkable xochitl[194]: Reading waveforms from /usr/share/remarkable/320_R382_AF5F11_ED103TC2M1_VB3300-KCD_TC.wbf
    Dec 04 17:13:55 reMarkable xochitl[194]: Running INIT (135 phases)
    Dec 04 17:13:55 reMarkable xochitl[194]: 1404 1872 16
    Dec 04 17:16:59 reMarkable xochitl[194]: Pan failed: Invalid argument