### PR TITLE
Open shm only if server is working & signal to systemd

### DIFF
--- a/src/shared/swtfb.cpp
+++ b/src/shared/swtfb.cpp
@@ -24,23 +24,21 @@ class SwtFB {
 
 public:
   SwtFB()
-  : config(read_config()) {
-    setFunc();
-    initQT();
-  }
+  : config(read_config()) {}
 
-  void setFunc() {
+  bool setFunc() {
     auto search = config.find("getInstance");
 
     if (search == config.end()) {
       std::cerr << "Missing address for function 'getInstance'\n"
         "PLEASE SEE https://github.com/ddvk/remarkable2-framebuffer/issues/18\n";
-      std::exit(-1);
+      return false;
     }
 
     void* address = std::get<void*>(search->second);
     f_getInstance = (uint32_t * (*)(void)) address;
     std::cerr << "getInstance() at address: " << address << '\n';
+    return true;
   }
 
   void initQT() {


### PR DESCRIPTION
This changeset is aimed at giving more information to external processes as to whether the rm2fb server is running or not, in two ways:

* The shared memory segment will only be instantiated after the server has confirmed it has all the offsets it needs to work. Otherwise, the server process will exit with code 255 (as before), without creating the shm. This enables other processes to check whether the server has been started by testing for the existence of `/dev/shm/swtfb.01` (this fixes #76).
* The server will now send a signal to systemd when it is done initializing, so that boot-time ordering of dependencies can work properly. This requires changing the rm2fb.service type to `notify`:

```diff
 [Unit]
 Description=reMarkable 2 Framebuffer Server
 Before=xochitl.service launcher.service remarkable-reboot.service remarkable-shutdown.service
 After=opt.mount
 StartLimitInterval=30
 StartLimitBurst=5
 Conflicts=
 ConditionFileNotEmpty=/opt/lib/librm2fb_server.so.1

 [Service]
+Type=notify
 ExecStart=/usr/bin/xochitl
 Restart=on-failure
 RestartSec=5
 Environment="HOME=/home/root"
 Environment="LD_PRELOAD=/home/root/librm2fb_server.so.1.0.1"

 [Install]
 WantedBy=multi-user.target
```

To test, replace both librm2fb_server and librm2fb_client, update the rm2fb service definition as above, then:

* Enable `rm2fb.service` and `xochitl.service`, disable any launcher, and reboot. After reboot, check the logs of `xochitl`: they should start with lines saying `Sourcing /opt/etc/xochitl.env.d/rm2fb-preload.env`, `Replacing 'update' (at 0x3a9cdc): OK`, etc. You should **NOT** see a line saying `rm2fb server is not running: starting without rm2fb client`. Take note of the timestamp of xochitl’s first log line. Check the logs of `rm2fb`, make sure that the timestamp of the log line saying `WAITING FOR SEND UPDATE ON MSG Q` is lower than or equal to the timestamp of the first xochitl log line.
* Edit `/etc/version` to simulate running an unsupported OS release. Reboot. Check the status of `rm2fb.server`, it should have failed with exit code 255. Check that `/dev/shm/swtfb.01` does not exist. Xochitl should start anyway. Check the logs of `xochitl`: you should now see the line saying `rm2fb server is not running: starting without rm2fb client` in place of the `Replacing...` lines.