### PR TITLE
Fix crash due to invalid notify address for 3.0.4.1305.

### DIFF
--- a/src/shared/config.cpp
+++ b/src/shared/config.cpp
@@ -380,8 +380,7 @@ create addr 0x5560b0
 shutdown addr 0x556040
 wait addr 0x554f58
 getInstance addr 0x549674
-notify addr 0x552f74
-
+notify addr 0x547a94
 
 !20221219100426
 version	str 3.1.0.1346


### PR DESCRIPTION
Thanks to @rotech for pointing out the correct address.

https://github.com/ddvk/remarkable2-framebuffer/commit/958b57c7e2b8f3c01d3e7f4314ccf7d09688ae34#commitcomment-97824454